### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -7,9 +7,9 @@ function init --on-event init_composer
 
   # get composer path
   if test -z "$COMPOSER_BIN"
-    if available "composer.phar"
+    if type -q composer.phar
       set -gx COMPOSER_BIN (which composer.phar)
-    else if available "composer"
+    else if type -q composer
       set -gx COMPOSER_BIN (which composer)
     else
       echo "FAILED to find Composer! Please install composer.phar to your PATH."


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
