### PR TITLE
Don't add to path repeatedly on every reload

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -2,7 +2,10 @@
 if test -z "$COMPOSER_BIN_PATH"
   set -gx COMPOSER_BIN_PATH $HOME/.composer/vendor/bin
 end
-set PATH $COMPOSER_BIN_PATH $PATH
+
+if not contains "$COMPOSER_BIN_PATH" $PATH
+  set PATH "$COMPOSER_BIN_PATH" $PATH
+end
 
 # get composer path
 if test -z "$COMPOSER_BIN"


### PR DESCRIPTION
Right now this plugin adds `$COMPOSER_BIN_PATH` to the `$PATH` whether it is already there or not. This causes the path to grow very large on every shell reload, etc. This fixes the issue by only adding to the path if it is not already there.
